### PR TITLE
fix compilation error

### DIFF
--- a/src/kiwi/base/files/file.h
+++ b/src/kiwi/base/files/file.h
@@ -32,7 +32,7 @@ typedef struct stat stat_wrapper_t;
 }
 #elif BUILDFLAG(IS_POSIX)
 struct stat64;
-namespace base {
+namespace kiwi::base {
 typedef struct stat64 stat_wrapper_t;
 }
 #endif

--- a/src/kiwi/base/files/file_enumerator_win.cc
+++ b/src/kiwi/base/files/file_enumerator_win.cc
@@ -12,6 +12,10 @@
 #include "base/win/shlwapi.h"
 #include "base/win/windows_types.h"
 
+#ifdef _MSC_VER
+#pragma comment(lib, "Shlwapi.lib")
+#endif
+
 #if defined(max)
 #undef max
 #endif

--- a/src/kiwi/third_party/CMakeLists.txt
+++ b/src/kiwi/third_party/CMakeLists.txt
@@ -10,6 +10,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(glog)
 add_subdirectory(SDL2)
 add_subdirectory(nes_apu)


### PR DESCRIPTION
在ubuntu20.04编译时出现两个编译错误：
1、Kiwi-Machine/src/kiwi/./base/files/file.h:115:37: error: ‘stat_wrapper_t’ has not been declared
2、third_party/nes_apu/libnes_apu.a(Blip_Buffer.cpp.o): relocation R_X86_64_PC32 against symbol `_ZSt7nothrow@@GLIBCXX_3.4' can not be used when making a shared object; recompile with -fPIC

在win11编译时出现:
无法解析的外部符号 __imp__PathMatchSpecW